### PR TITLE
Fixed IL2CPP compilation error

### DIFF
--- a/Assets/Scripts/UniPromise/RejectedPromise.cs
+++ b/Assets/Scripts/UniPromise/RejectedPromise.cs
@@ -29,7 +29,7 @@ namespace UniPromise {
 		}
 		
 		public override Promise<U> Then<U> (Func<T, Promise<U>> done) {
-			return this;
+			return new RejectedPromise<U>(e);
 		}
 		
 		public override Promise<T> Clone () {


### PR DESCRIPTION
Fixed IL2CPP compilation error: cannot initialize return object of type 'Promise_1_t6354 ​*' with an lvalue of type 'RejectedPromise_1_t10237 *​' return __this;
