### PR TITLE
Added new Then method which can receive an Action to make describing more simple.

### DIFF
--- a/Assets/Scripts/UniPromise/AbstractPromise.cs
+++ b/Assets/Scripts/UniPromise/AbstractPromise.cs
@@ -38,7 +38,9 @@ namespace UniPromise {
 		public abstract Promise<U> Then<U>(
 			Func<T, Promise<U>> done, Func<Exception, Promise<U>> fail, Func<Promise<U>> disposed) where U : class;
 
-		[Obsolete("This function is identical to Then().")]
+		public abstract Promise<T> Then (Action<T> done);
+
+		[Obsolete ("This function is identical to Then().")]
 		public Promise<U> ThenWithCatch<U>(Func<T, Promise<U>> done) where U : class {
 			return Then(t => {
 				try{

--- a/Assets/Scripts/UniPromise/Promise.cs
+++ b/Assets/Scripts/UniPromise/Promise.cs
@@ -11,7 +11,7 @@ namespace UniPromise {
 		bool IsDisposed { get; }
 
 		Promise<T> Done(Action<T> doneCallback);
-		
+
 		Promise<T> Fail(Action<Exception> failedCallback);
 
 		Promise<T> Disposed(Action disposedCallback);
@@ -19,13 +19,15 @@ namespace UniPromise {
 		Promise<T> Finally (Action callback, bool includeDisposed = true);
 
 		Promise<T> ThrowOnFail ();
-		
+
 		Promise<U> Then<U>(Func<T, Promise<U>> done) where U : class;
 
 		Promise<U> Then<U>(Func<T, Promise<U>> done, Func<Exception, Promise<U>> fail) where U : class;
 
 		Promise<U> Then<U>(
 			Func<T, Promise<U>> done, Func<Exception, Promise<U>> fail, Func<Promise<U>> disposed) where U : class;
+
+		Promise<T> Then(Action<T> done);
 
 		Promise<U> Select<U> (Func<T, U> selector) where U : class;
 

--- a/Assets/Tests/Editor/PromiseTest.cs
+++ b/Assets/Tests/Editor/PromiseTest.cs
@@ -146,6 +146,33 @@ namespace UniPromise.Tests {
 		}
 
 		[Test]
+		public void TestSuccessInThenWithAction() {
+			var callChecker = new DoneCallback<int> ();
+			var source = new Deferred<TWrapper<int>> ();
+			source.Resolve (1.Wrap());
+			source.Then (i => {
+				callChecker.Create()(i.val);
+			})
+				.Done (doneCallback.Create ()).Fail (failCallback.Create ());
+			Assert.That (callChecker.IsCalled, Is.True);
+			Assert.That (doneCallback.IsCalled, Is.True);
+			Assert.That (failCallback.IsCalled, Is.False);
+		}
+
+		[Test]
+		public void TestExceptionInThenWithAction ()
+		{
+			var source = new Deferred<TWrapper<int>> ();
+			source.Resolve (1.Wrap ());
+			source.Then (_ => {
+				throw new Exception ();
+			})
+				.Done (doneCallback.Create ()).Fail (failCallback.Create ());
+			Assert.That (doneCallback.IsCalled, Is.False);
+			Assert.That (failCallback.IsCalled, Is.True);
+		}
+
+		[Test]
 		public void TestSelect() {
 			var actual = 0;
 			Promises.Resolved (1.Wrap()).Select (_ => 2.Wrap()).Done (_ => actual++);

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ class Sample : MonoBehaviour {
   public void ChainTest() {
     PromiseResolved()
       .Then(_ => {
+        // You can pass just an Action which does stuff sequentially
+        Debug.Log("Blur");
+      })
+      .Then(_ => {
           return PromiseRejected();
         })
       .Then(_ => {


### PR DESCRIPTION
こういうのあると便利だと思うんですがどうでしょう？

ユースケース的には、例えば以下のようなコードがある時に
```C#
return Promises.Resolved (CUnit.Default)
  .Then (_ => {
    DoSynchronousA();

    if (withMigration) {
      return DoPromiseC ();
    }
    return Promises.Resolved (CUnit.Default);
  })
  .Then (_ => {
    DoSynchronousB();

    if (withMigration) {
      return DoPromiseD ();
    }
    return Promises.Resolved (CUnit.Default);
  });
```

`DoSynchronousXX` と `DoPromiseXX` を入れ替えたい！となった場合、ちょっと変更がややこしくなる(まあ↑のサンプルはたいしたことないですが・・・)ので、

最初から
```C#
return Promises.Resolved (CUnit.Default)
  .Then (_ => DoSynchronousA())
  .Then (_ => {
    if (withMigration) {
      return DoPromiseC ();
    }
    return Promises.Resolved (CUnit.Default);
  })
  .Then (_ => DoSynchronousB())
  .Then (_ => {
    if (withMigration) {
      return DoPromiseD ();
    }
    return Promises.Resolved (CUnit.Default);
  });
```
こんな風に書いておくと、処理の塊も把握しやすいしよいのでは？という意図です。